### PR TITLE
Shorten syntax in thrown() examples

### DIFF
--- a/spock-website/index.html
+++ b/spock-website/index.html
@@ -175,7 +175,7 @@
         calculator.calculate(<span class="number">10</span>, <span class="number">0</span>, <span class="string">"/"</span>)
 
         <span class="keyword">then:</span> <span class="comment">"An IllegalArgumentException is thrown"</span>
-        <span class="keyword">def</span> exception = thrown(<span class="class-name">IllegalArgumentException</span>)
+        <span class="class-name">IllegalArgumentException</span> exception = thrown()
 
         <span class="keyword">and:</span> <span class="comment">"The exception message is correct"</span>
         exception.message == <span class="string">"Cannot divide by zero"</span>
@@ -189,7 +189,7 @@
         calculator.calculate(<span class="number">1</span>, <span class="number">2</span>, <span class="string">"**"</span>)
 
         <span class="keyword">then:</span> <span class="comment">"An IllegalArgumentException is thrown"</span>
-        <span class="keyword">def</span> exception = thrown(<span class="class-name">IllegalArgumentException</span>)
+        <span class="class-name">IllegalArgumentException</span> exception = thrown()
 
         <span class="keyword">and:</span> <span class="comment">"The exception message is correct"</span>
         exception.message == <span class="string">"Invalid operation: **"</span>

--- a/spock-website/tests/__screenshots__/chromium/visual.spec.ts/index.png
+++ b/spock-website/tests/__screenshots__/chromium/visual.spec.ts/index.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9453702727bae565b3f4aede02e1ceb859a0f576ca443521e7c6ec0e46ebde2f
-size 436322
+oid sha256:8c20db95119e99400378caf1a48daa06f970812ebd82a45664141fd609e5676f
+size 437013

--- a/spock-website/tests/__screenshots__/firefox/visual.spec.ts/index.png
+++ b/spock-website/tests/__screenshots__/firefox/visual.spec.ts/index.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:279098831bbfd802d398e46ba6c2699a6dbdd6e18a42ea56237ffac44647e0e7
-size 699204
+oid sha256:c66e2fec83a07f0076d257ff3161087bb27f118bf6100ec4292b7425e629e44d
+size 701111


### PR DESCRIPTION
`def exception = thrown(IllegalArgumentException)` → `IllegalArgumentException exception = thrown()`
